### PR TITLE
Increase service probe line size, better error handling

### DIFF
--- a/service_scan.cc
+++ b/service_scan.cc
@@ -1303,7 +1303,8 @@ void ServiceProbe::addMatch(const char *match, int lineno) {
    (servicematch) which use this */
 void parse_nmap_service_probe_file(AllProbes *AP, const char *filename) {
   ServiceProbe *newProbe = NULL;
-  char line[2048];
+  /
+  char line[16384];
   int lineno = 0;
   FILE *fp;
 
@@ -1331,6 +1332,10 @@ void parse_nmap_service_probe_file(AllProbes *AP, const char *filename) {
     if (strncmp(line, "Probe ", 6) != 0)
       fatal("Parse error on line %d of nmap-service-probes file: %s -- line was expected to begin with \"Probe \" or \"Exclude \"", lineno, filename);
 
+    if (strnlen(line, sizeof(line)) >= sizeof(line) - 1) {
+      fatal("Parse error on line %d of nmap-service-probes file: %s -- line is too long for buffer, max length is %lu", lineno, filename, sizeof(line));
+    }
+
     newProbe = new ServiceProbe();
     newProbe->setProbeDetails(line + 6, lineno);
 
@@ -1339,6 +1344,8 @@ void parse_nmap_service_probe_file(AllProbes *AP, const char *filename) {
       lineno++;
       if (*line == '\n' || *line == '#')
         continue;
+
+      if strnlen(
 
       if (strncmp(line, "Probe ", 6) == 0) {
         if (newProbe->isNullProbe()) {


### PR DESCRIPTION
We added a probe that was over the 2048 limit, and were met with the error "Parse error on line %d of nmap-service-probes -- no ending delimiter for probe string", which was confusing since we formatting it correctly.   

This increases the max line length, and adds a more appropriate error saying that the max line length was hit.  